### PR TITLE
test: also allow woofing

### DIFF
--- a/test
+++ b/test
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 
-echo "purrrrrrr"
+purring_command="$1"
+case "$purring_command" in
+    "purr") echo "purrrrrrrr" ;;
+    "woof") echo "bark bark!" ;;
+    *) echo "Do not know how to '$purring_command'" ;;
+esac
 exit 1


### PR DESCRIPTION
@cdetrio - so, to test out your theory, I made a `purring-simulator` repo, and have a branch called `master`. Actually the difficulty was `git push --set-upstream-to origin master`, which I tab-completed, and almost set the upstream to `master` instead of `masterr`. Indeed, I was in danger, in a purring-simulator repository, of pushing to `master` when I intended `masterr` (as @axic conjectured).